### PR TITLE
[BUG] Changes of dependencies are propagated to wrong class and computed property is never teardowned

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -13,7 +13,7 @@ function findOrCreatePropertyInstance(propertyClass, context, key) {
   }
 
   let property = propertiesForContext[key];
-  if (property) {
+  if (property && property instanceof propertyClass) {
     return property;
   }
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -24,6 +24,13 @@ function findOrCreatePropertyInstance(propertyClass, context, key) {
   });
 
   propertiesForContext[key] = property;
+
+  if (context instanceof Ember.Component) {
+    // in case component would be destroyed
+    // we need to destroy computed property as well
+    context.one('willDestroyElement', () => property.destroy());
+  }
+
   return property;
 }
 
@@ -39,12 +46,27 @@ const ClassBasedComputedProperty = EmberObject.extend({
 ClassBasedComputedProperty.reopenClass({
   property(klass) {
     return function(...dependencies) {
-      return computed(...dependencies, function(key) {
+      const generatedComputedProperty = computed(...dependencies, function(key) {
         let property = findOrCreatePropertyInstance(klass, this, key);
+
+        const isComputedPropertyOrphaned = () => {
+          //in case new computed property would be generated under the same key
+          //of context object
+          if(this[key] !== generatedComputedProperty) {
+            //we need to destroy previous one
+            property.destroy();
+            //also there is no longer need to check it
+            this.removeObserver(key, isComputedPropertyOrphaned);
+          }
+        };
+
+        this.addObserver(key, isComputedPropertyOrphaned);
 
         let values = A(dependencies).map((dep) => this.get(dep));
         return property.compute(...values);
       });
+
+      return generatedComputedProperty;
     };
   }
 });


### PR DESCRIPTION
Changes of dependencies are propagated to wrong class in case one class was switch to another one under the same property name.