### PR TITLE
allow ember-weakmap 2.x and 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-weakmap": "^2.0.0",
+    "ember-weakmap": "^2.0.0 || ^3.0.0",
     "ember-getowner-polyfill": "^1.1.0 || ^2.0.0",
     "ember-cli-babel": "^6.3.0"
   },


### PR DESCRIPTION
closes #54 