### PR TITLE
test with headless chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
   - "6"
 
 sudo: false
+dist: trusty
+
+addons:
+  chrome: stable
 
 cache:
   directories:
@@ -11,8 +15,6 @@ cache:
 
 before_install:
   - npm config set spin false
-  - npm install -g phantomjs-prebuilt
-  - phantomjs --version
 
 install:
   - npm install

--- a/testem.js
+++ b/testem.js
@@ -3,10 +3,20 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
-    'PhantomJS'
+    'Chrome'
   ],
   launch_in_dev: [
-    'PhantomJS',
     'Chrome'
-  ]
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ]
+    }
+  }
 };


### PR DESCRIPTION
This switches from PhantomJS to Headless Chrome on CI and unblocks #66 which fails as Ember 3.0 which is now canary does not run with Phantom anymore.